### PR TITLE
Update to use Refit version 6.3.2.

### DIFF
--- a/Camunda.Api.Client.Tests/Camunda.Api.Client.Tests.csproj
+++ b/Camunda.Api.Client.Tests/Camunda.Api.Client.Tests.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netcoreapp2.0</TargetFramework>
+    <TargetFramework>net461</TargetFramework>
 
     <IsPackable>false</IsPackable>
 

--- a/Camunda.Api.Client/Camunda.Api.Client.csproj
+++ b/Camunda.Api.Client/Camunda.Api.Client.csproj
@@ -26,7 +26,10 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Refit" Version="5.0.23" />
+    <PackageReference Include="Newtonsoft.Json" Version="13.0.1" />
+    <PackageReference Include="Refit" Version="6.3.2" />
+    <PackageReference Include="Refit.Newtonsoft.Json" Version="6.3.2" />
+    <PackageReference Include="Refit.Xml" Version="6.3.2" />
     <PackageReference Include="System.Net.Http" Version="4.3.4" />
   </ItemGroup>
 

--- a/Camunda.Api.Client/CamundaClient.cs
+++ b/Camunda.Api.Client/CamundaClient.cs
@@ -27,8 +27,6 @@ using Camunda.Api.Client.Tenant;
 using Camunda.Api.Client.User;
 using Camunda.Api.Client.UserTask;
 using Camunda.Api.Client.VariableInstance;
-
-using JsonSerializer = Newtonsoft.Json.JsonSerializer;
 using Camunda.Api.Client.Filter;
 
 namespace Camunda.Api.Client
@@ -65,7 +63,7 @@ namespace Camunda.Api.Client
         private RefitSettings _refitSettings;
         private HttpMessageHandler _httpMessageHandler;
         internal static JsonSerializerSettings JsonSerializerSettings { get; private set; }
-        internal static IContentSerializer JsonContentSerializer { get; private set; }
+        internal static IHttpContentSerializer JsonContentSerializer { get; private set; }
 
         internal class HistoricApi
         {
@@ -97,7 +95,7 @@ namespace Camunda.Api.Client
             JsonSerializerSettings.Converters.Add(new StringEnumConverter());
             JsonSerializerSettings.Converters.Add(new CustomIsoDateTimeConverter());
 
-            JsonContentSerializer = JsonContentSerializer ?? new JsonContentSerializer(JsonSerializerSettings);
+            JsonContentSerializer = JsonContentSerializer ?? new NewtonsoftJsonContentSerializer(JsonSerializerSettings);
         }
 
         private class CustomIsoDateTimeConverter : Newtonsoft.Json.Converters.IsoDateTimeConverter


### PR DESCRIPTION
This doesn't address the entire purpose of updating to Refit 6.x, but it is the first step for projects that are already using Refit 6 and need compatibility.

It needs a version number bump, but I wasn't sure on your norms for updating version numbers.